### PR TITLE
RFC: redesign of metamodel for map key and map value types

### DIFF
--- a/lib/metamodel.cto
+++ b/lib/metamodel.cto
@@ -72,24 +72,41 @@ abstract concept Declaration {
   o Range location optional
 }
 
+abstract concept MapKeyType {
+  o Decorator[] decorators optional
+  o Range location optional
+}
+
+abstract concept MapValueType {
+  o Decorator[] decorators optional
+  o Range location optional
+}
+
 concept MapDeclaration extends Declaration {
   o MapKeyType key
-  o AggregateValueType value
+  o MapValueType value
 }
 
-concept MapKeyType {
+concept StringMapKeyType extends MapKeyType {}
+concept DateTimeMapKeyType extends MapKeyType {}
+
+concept ObjectMapKeyType extends MapKeyType {
   o TypeIdentifier type
-  o Decorator[] decorators optional
-  o Range location optional
 }
 
-concept AggregateValueType {
+concept BooleanMapValueType extends MapValueType {}
+concept DateTimeMapValueType extends MapValueType {}
+concept StringMapValueType extends MapValueType {}
+concept IntegerMapValueType extends MapValueType {}
+concept LongMapValueType extends MapValueType {}
+concept DoubleMapValueType extends MapValueType {}
+
+concept ObjectMapValueType extends MapValueType {
   o TypeIdentifier type
-  o Decorator[] decorators optional
-  o Range location optional
 }
 
-concept AggregateRelationshipValueType extends AggregateValueType {
+concept RelationshipMapValueType extends MapValueType {
+  o TypeIdentifier type
 }
 
 concept EnumDeclaration extends Declaration {

--- a/lib/metamodel.json
+++ b/lib/metamodel.json
@@ -1,1192 +1,1298 @@
 {
-    "$class": "concerto.metamodel@1.0.0.Model",
-    "decorators": [
-        {
-            "$class": "concerto.metamodel@1.0.0.Decorator",
-            "name": "DotNetNamespace",
-            "arguments": [
-                {
-                    "$class": "concerto.metamodel@1.0.0.DecoratorString",
-                    "value": "AccordProject.Concerto.Metamodel"
-                }
-            ]
-        }
-    ],
-    "namespace": "concerto.metamodel@1.0.0",
-    "imports": [],
-    "declarations": [
-        {
-            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-            "name": "Position",
-            "isAbstract": false,
-            "properties": [
-                {
-                    "$class": "concerto.metamodel@1.0.0.IntegerProperty",
-                    "name": "line",
-                    "isArray": false,
-                    "isOptional": false
-                },
-                {
-                    "$class": "concerto.metamodel@1.0.0.IntegerProperty",
-                    "name": "column",
-                    "isArray": false,
-                    "isOptional": false
-                },
-                {
-                    "$class": "concerto.metamodel@1.0.0.IntegerProperty",
-                    "name": "offset",
-                    "isArray": false,
-                    "isOptional": false
-                }
-            ]
-        },
-        {
-            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-            "name": "Range",
-            "isAbstract": false,
-            "properties": [
-                {
-                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-                    "name": "start",
-                    "type": {
-                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                        "name": "Position"
-                    },
-                    "isArray": false,
-                    "isOptional": false
-                },
-                {
-                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-                    "name": "end",
-                    "type": {
-                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                        "name": "Position"
-                    },
-                    "isArray": false,
-                    "isOptional": false
-                },
-                {
-                    "$class": "concerto.metamodel@1.0.0.StringProperty",
-                    "name": "source",
-                    "isArray": false,
-                    "isOptional": true
-                }
-            ]
-        },
-        {
-            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-            "name": "TypeIdentifier",
-            "isAbstract": false,
-            "properties": [
-                {
-                    "$class": "concerto.metamodel@1.0.0.StringProperty",
-                    "name": "name",
-                    "isArray": false,
-                    "isOptional": false
-                },
-                {
-                    "$class": "concerto.metamodel@1.0.0.StringProperty",
-                    "name": "namespace",
-                    "isArray": false,
-                    "isOptional": true
-                }
-            ]
-        },
-        {
-            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-            "name": "DecoratorLiteral",
-            "isAbstract": true,
-            "properties": [
-                {
-                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-                    "name": "location",
-                    "type": {
-                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                        "name": "Range"
-                    },
-                    "isArray": false,
-                    "isOptional": true
-                }
-            ]
-        },
-        {
-            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-            "name": "DecoratorString",
-            "isAbstract": false,
-            "properties": [
-                {
-                    "$class": "concerto.metamodel@1.0.0.StringProperty",
-                    "name": "value",
-                    "isArray": false,
-                    "isOptional": false
-                }
-            ],
-            "superType": {
-                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                "name": "DecoratorLiteral"
-            }
-        },
-        {
-            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-            "name": "DecoratorNumber",
-            "isAbstract": false,
-            "properties": [
-                {
-                    "$class": "concerto.metamodel@1.0.0.DoubleProperty",
-                    "name": "value",
-                    "isArray": false,
-                    "isOptional": false
-                }
-            ],
-            "superType": {
-                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                "name": "DecoratorLiteral"
-            }
-        },
-        {
-            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-            "name": "DecoratorBoolean",
-            "isAbstract": false,
-            "properties": [
-                {
-                    "$class": "concerto.metamodel@1.0.0.BooleanProperty",
-                    "name": "value",
-                    "isArray": false,
-                    "isOptional": false
-                }
-            ],
-            "superType": {
-                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                "name": "DecoratorLiteral"
-            }
-        },
-        {
-            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-            "name": "DecoratorTypeReference",
-            "isAbstract": false,
-            "properties": [
-                {
-                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-                    "name": "type",
-                    "type": {
-                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                        "name": "TypeIdentifier"
-                    },
-                    "isArray": false,
-                    "isOptional": false
-                },
-                {
-                    "$class": "concerto.metamodel@1.0.0.BooleanProperty",
-                    "name": "isArray",
-                    "isArray": false,
-                    "isOptional": false,
-                    "defaultValue": false
-                }
-            ],
-            "superType": {
-                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                "name": "DecoratorLiteral"
-            }
-        },
-        {
-            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-            "name": "Decorator",
-            "isAbstract": false,
-            "properties": [
-                {
-                    "$class": "concerto.metamodel@1.0.0.StringProperty",
-                    "name": "name",
-                    "isArray": false,
-                    "isOptional": false
-                },
-                {
-                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-                    "name": "arguments",
-                    "type": {
-                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                        "name": "DecoratorLiteral"
-                    },
-                    "isArray": true,
-                    "isOptional": true
-                },
-                {
-                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-                    "name": "location",
-                    "type": {
-                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                        "name": "Range"
-                    },
-                    "isArray": false,
-                    "isOptional": true
-                }
-            ]
-        },
-        {
-            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-            "name": "Identified",
-            "isAbstract": false,
-            "properties": []
-        },
-        {
-            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-            "name": "IdentifiedBy",
-            "isAbstract": false,
-            "properties": [
-                {
-                    "$class": "concerto.metamodel@1.0.0.StringProperty",
-                    "name": "name",
-                    "isArray": false,
-                    "isOptional": false
-                }
-            ],
-            "superType": {
-                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                "name": "Identified"
-            }
-        },
-        {
-            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-            "name": "Declaration",
-            "isAbstract": true,
-            "properties": [
-                {
-                    "$class": "concerto.metamodel@1.0.0.StringProperty",
-                    "name": "name",
-                    "isArray": false,
-                    "isOptional": false,
-                    "validator": {
-                        "$class": "concerto.metamodel@1.0.0.StringRegexValidator",
-                        "pattern": "^(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$",
-                        "flags": "u"
-                    }
-                },
-                {
-                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-                    "name": "decorators",
-                    "type": {
-                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                        "name": "Decorator"
-                    },
-                    "isArray": true,
-                    "isOptional": true
-                },
-                {
-                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-                    "name": "location",
-                    "type": {
-                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                        "name": "Range"
-                    },
-                    "isArray": false,
-                    "isOptional": true
-                }
-            ]
-        },
+	"$class": "concerto.metamodel@1.0.0.Model",
+	"decorators": [
+		{
+			"$class": "concerto.metamodel@1.0.0.Decorator",
+			"name": "DotNetNamespace",
+			"arguments": [
 				{
-					"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-					"name": "MapDeclaration",
-					"isAbstract": false,
-					"properties": [
-						{
-							"$class": "concerto.metamodel@1.0.0.ObjectProperty",
-							"name": "key",
-							"type": {
-								"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-								"name": "MapKeyType"
-							},
-							"isArray": false,
-							"isOptional": false
-						},
-						{
-							"$class": "concerto.metamodel@1.0.0.ObjectProperty",
-							"name": "value",
-							"type": {
-								"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-								"name": "AggregateValueType"
-							},
-							"isArray": false,
-							"isOptional": false
-						}
-					],
-					"superType": {
+					"$class": "concerto.metamodel@1.0.0.DecoratorString",
+					"value": "AccordProject.Concerto.Metamodel"
+				}
+			]
+		}
+	],
+	"namespace": "concerto.metamodel@1.0.0",
+	"imports": [],
+	"declarations": [
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "Position",
+			"isAbstract": false,
+			"properties": [
+				{
+					"$class": "concerto.metamodel@1.0.0.IntegerProperty",
+					"name": "line",
+					"isArray": false,
+					"isOptional": false
+				},
+				{
+					"$class": "concerto.metamodel@1.0.0.IntegerProperty",
+					"name": "column",
+					"isArray": false,
+					"isOptional": false
+				},
+				{
+					"$class": "concerto.metamodel@1.0.0.IntegerProperty",
+					"name": "offset",
+					"isArray": false,
+					"isOptional": false
+				}
+			]
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "Range",
+			"isAbstract": false,
+			"properties": [
+				{
+					"$class": "concerto.metamodel@1.0.0.ObjectProperty",
+					"name": "start",
+					"type": {
+						"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+						"name": "Position"
+					},
+					"isArray": false,
+					"isOptional": false
+				},
+				{
+					"$class": "concerto.metamodel@1.0.0.ObjectProperty",
+					"name": "end",
+					"type": {
+						"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+						"name": "Position"
+					},
+					"isArray": false,
+					"isOptional": false
+				},
+				{
+					"$class": "concerto.metamodel@1.0.0.StringProperty",
+					"name": "source",
+					"isArray": false,
+					"isOptional": true
+				}
+			]
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "TypeIdentifier",
+			"isAbstract": false,
+			"properties": [
+				{
+					"$class": "concerto.metamodel@1.0.0.StringProperty",
+					"name": "name",
+					"isArray": false,
+					"isOptional": false
+				},
+				{
+					"$class": "concerto.metamodel@1.0.0.StringProperty",
+					"name": "namespace",
+					"isArray": false,
+					"isOptional": true
+				}
+			]
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "DecoratorLiteral",
+			"isAbstract": true,
+			"properties": [
+				{
+					"$class": "concerto.metamodel@1.0.0.ObjectProperty",
+					"name": "location",
+					"type": {
+						"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+						"name": "Range"
+					},
+					"isArray": false,
+					"isOptional": true
+				}
+			]
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "DecoratorString",
+			"isAbstract": false,
+			"properties": [
+				{
+					"$class": "concerto.metamodel@1.0.0.StringProperty",
+					"name": "value",
+					"isArray": false,
+					"isOptional": false
+				}
+			],
+			"superType": {
+				"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+				"name": "DecoratorLiteral"
+			}
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "DecoratorNumber",
+			"isAbstract": false,
+			"properties": [
+				{
+					"$class": "concerto.metamodel@1.0.0.DoubleProperty",
+					"name": "value",
+					"isArray": false,
+					"isOptional": false
+				}
+			],
+			"superType": {
+				"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+				"name": "DecoratorLiteral"
+			}
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "DecoratorBoolean",
+			"isAbstract": false,
+			"properties": [
+				{
+					"$class": "concerto.metamodel@1.0.0.BooleanProperty",
+					"name": "value",
+					"isArray": false,
+					"isOptional": false
+				}
+			],
+			"superType": {
+				"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+				"name": "DecoratorLiteral"
+			}
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "DecoratorTypeReference",
+			"isAbstract": false,
+			"properties": [
+				{
+					"$class": "concerto.metamodel@1.0.0.ObjectProperty",
+					"name": "type",
+					"type": {
+						"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+						"name": "TypeIdentifier"
+					},
+					"isArray": false,
+					"isOptional": false
+				},
+				{
+					"$class": "concerto.metamodel@1.0.0.BooleanProperty",
+					"name": "isArray",
+					"isArray": false,
+					"isOptional": false,
+					"defaultValue": false
+				}
+			],
+			"superType": {
+				"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+				"name": "DecoratorLiteral"
+			}
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "Decorator",
+			"isAbstract": false,
+			"properties": [
+				{
+					"$class": "concerto.metamodel@1.0.0.StringProperty",
+					"name": "name",
+					"isArray": false,
+					"isOptional": false
+				},
+				{
+					"$class": "concerto.metamodel@1.0.0.ObjectProperty",
+					"name": "arguments",
+					"type": {
+						"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+						"name": "DecoratorLiteral"
+					},
+					"isArray": true,
+					"isOptional": true
+				},
+				{
+					"$class": "concerto.metamodel@1.0.0.ObjectProperty",
+					"name": "location",
+					"type": {
+						"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+						"name": "Range"
+					},
+					"isArray": false,
+					"isOptional": true
+				}
+			]
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "Identified",
+			"isAbstract": false,
+			"properties": []
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "IdentifiedBy",
+			"isAbstract": false,
+			"properties": [
+				{
+					"$class": "concerto.metamodel@1.0.0.StringProperty",
+					"name": "name",
+					"isArray": false,
+					"isOptional": false
+				}
+			],
+			"superType": {
+				"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+				"name": "Identified"
+			}
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "Declaration",
+			"isAbstract": true,
+			"properties": [
+				{
+					"$class": "concerto.metamodel@1.0.0.StringProperty",
+					"name": "name",
+					"isArray": false,
+					"isOptional": false,
+					"validator": {
+						"$class": "concerto.metamodel@1.0.0.StringRegexValidator",
+						"pattern": "^(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$",
+						"flags": "u"
+					}
+				},
+				{
+					"$class": "concerto.metamodel@1.0.0.ObjectProperty",
+					"name": "decorators",
+					"type": {
+						"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+						"name": "Decorator"
+					},
+					"isArray": true,
+					"isOptional": true
+				},
+				{
+					"$class": "concerto.metamodel@1.0.0.ObjectProperty",
+					"name": "location",
+					"type": {
+						"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+						"name": "Range"
+					},
+					"isArray": false,
+					"isOptional": true
+				}
+			]
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "MapKeyType",
+			"isAbstract": true,
+			"properties": [
+				{
+					"$class": "concerto.metamodel@1.0.0.ObjectProperty",
+					"name": "decorators",
+					"type": {
+						"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+						"name": "Decorator"
+					},
+					"isArray": true,
+					"isOptional": true
+				},
+				{
+					"$class": "concerto.metamodel@1.0.0.ObjectProperty",
+					"name": "location",
+					"type": {
+						"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+						"name": "Range"
+					},
+					"isArray": false,
+					"isOptional": true
+				}
+			]
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "MapValueType",
+			"isAbstract": true,
+			"properties": [
+				{
+					"$class": "concerto.metamodel@1.0.0.ObjectProperty",
+					"name": "decorators",
+					"type": {
+						"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+						"name": "Decorator"
+					},
+					"isArray": true,
+					"isOptional": true
+				},
+				{
+					"$class": "concerto.metamodel@1.0.0.ObjectProperty",
+					"name": "location",
+					"type": {
+						"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+						"name": "Range"
+					},
+					"isArray": false,
+					"isOptional": true
+				}
+			]
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "MapDeclaration",
+			"isAbstract": false,
+			"properties": [
+				{
+					"$class": "concerto.metamodel@1.0.0.ObjectProperty",
+					"name": "key",
+					"type": {
+						"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+						"name": "MapKeyType"
+					},
+					"isArray": false,
+					"isOptional": false
+				},
+				{
+					"$class": "concerto.metamodel@1.0.0.ObjectProperty",
+					"name": "value",
+					"type": {
+						"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+						"name": "MapValueType"
+					},
+					"isArray": false,
+					"isOptional": false
+				}
+			],
+			"superType": {
+				"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+				"name": "Declaration"
+			}
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "StringMapKeyType",
+			"isAbstract": false,
+			"properties": [],
+			"superType": {
+				"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+				"name": "MapKeyType"
+			}
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "DateTimeMapKeyType",
+			"isAbstract": false,
+			"properties": [],
+			"superType": {
+				"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+				"name": "MapKeyType"
+			}
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "ObjectMapKeyType",
+			"isAbstract": false,
+			"properties": [
+				{
+					"$class": "concerto.metamodel@1.0.0.ObjectProperty",
+					"name": "type",
+					"type": {
+						"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+						"name": "TypeIdentifier"
+					},
+					"isArray": false,
+					"isOptional": false
+				}
+			],
+			"superType": {
+				"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+				"name": "MapKeyType"
+			}
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "BooleanMapValueType",
+			"isAbstract": false,
+			"properties": [],
+			"superType": {
+				"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+				"name": "MapValueType"
+			}
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "DateTimeMapValueType",
+			"isAbstract": false,
+			"properties": [],
+			"superType": {
+				"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+				"name": "MapValueType"
+			}
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "StringMapValueType",
+			"isAbstract": false,
+			"properties": [],
+			"superType": {
+				"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+				"name": "MapValueType"
+			}
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "IntegerMapValueType",
+			"isAbstract": false,
+			"properties": [],
+			"superType": {
+				"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+				"name": "MapValueType"
+			}
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "LongMapValueType",
+			"isAbstract": false,
+			"properties": [],
+			"superType": {
+				"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+				"name": "MapValueType"
+			}
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "DoubleMapValueType",
+			"isAbstract": false,
+			"properties": [],
+			"superType": {
+				"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+				"name": "MapValueType"
+			}
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "ObjectMapValueType",
+			"isAbstract": false,
+			"properties": [
+				{
+					"$class": "concerto.metamodel@1.0.0.ObjectProperty",
+					"name": "type",
+					"type": {
+						"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+						"name": "TypeIdentifier"
+					},
+					"isArray": false,
+					"isOptional": false
+				}
+			],
+			"superType": {
+				"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+				"name": "MapValueType"
+			}
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "RelationshipMapValueType",
+			"isAbstract": false,
+			"properties": [
+				{
+					"$class": "concerto.metamodel@1.0.0.ObjectProperty",
+					"name": "type",
+					"type": {
+						"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+						"name": "TypeIdentifier"
+					},
+					"isArray": false,
+					"isOptional": false
+				}
+			],
+			"superType": {
+				"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+				"name": "MapValueType"
+			}
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "EnumDeclaration",
+			"isAbstract": false,
+			"properties": [
+				{
+					"$class": "concerto.metamodel@1.0.0.ObjectProperty",
+					"name": "properties",
+					"type": {
+						"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+						"name": "EnumProperty"
+					},
+					"isArray": true,
+					"isOptional": false
+				}
+			],
+			"superType": {
+				"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+				"name": "Declaration"
+			}
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "EnumProperty",
+			"isAbstract": false,
+			"properties": [
+				{
+					"$class": "concerto.metamodel@1.0.0.StringProperty",
+					"name": "name",
+					"isArray": false,
+					"isOptional": false,
+					"validator": {
+						"$class": "concerto.metamodel@1.0.0.StringRegexValidator",
+						"pattern": "^(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$",
+						"flags": "u"
+					}
+				},
+				{
+					"$class": "concerto.metamodel@1.0.0.ObjectProperty",
+					"name": "decorators",
+					"type": {
+						"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+						"name": "Decorator"
+					},
+					"isArray": true,
+					"isOptional": true
+				},
+				{
+					"$class": "concerto.metamodel@1.0.0.ObjectProperty",
+					"name": "location",
+					"type": {
+						"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+						"name": "Range"
+					},
+					"isArray": false,
+					"isOptional": true
+				}
+			]
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "ConceptDeclaration",
+			"isAbstract": false,
+			"properties": [
+				{
+					"$class": "concerto.metamodel@1.0.0.BooleanProperty",
+					"name": "isAbstract",
+					"isArray": false,
+					"isOptional": false,
+					"defaultValue": false
+				},
+				{
+					"$class": "concerto.metamodel@1.0.0.ObjectProperty",
+					"name": "identified",
+					"type": {
+						"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+						"name": "Identified"
+					},
+					"isArray": false,
+					"isOptional": true
+				},
+				{
+					"$class": "concerto.metamodel@1.0.0.ObjectProperty",
+					"name": "superType",
+					"type": {
+						"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+						"name": "TypeIdentifier"
+					},
+					"isArray": false,
+					"isOptional": true
+				},
+				{
+					"$class": "concerto.metamodel@1.0.0.ObjectProperty",
+					"name": "properties",
+					"type": {
+						"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+						"name": "Property"
+					},
+					"isArray": true,
+					"isOptional": false
+				}
+			],
+			"superType": {
+				"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+				"name": "Declaration"
+			}
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "AssetDeclaration",
+			"isAbstract": false,
+			"properties": [],
+			"superType": {
+				"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+				"name": "ConceptDeclaration"
+			}
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "ParticipantDeclaration",
+			"isAbstract": false,
+			"properties": [],
+			"superType": {
+				"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+				"name": "ConceptDeclaration"
+			}
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "TransactionDeclaration",
+			"isAbstract": false,
+			"properties": [],
+			"superType": {
+				"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+				"name": "ConceptDeclaration"
+			}
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "EventDeclaration",
+			"isAbstract": false,
+			"properties": [],
+			"superType": {
+				"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+				"name": "ConceptDeclaration"
+			}
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "Property",
+			"isAbstract": true,
+			"properties": [
+				{
+					"$class": "concerto.metamodel@1.0.0.StringProperty",
+					"name": "name",
+					"isArray": false,
+					"isOptional": false,
+					"validator": {
+						"$class": "concerto.metamodel@1.0.0.StringRegexValidator",
+						"pattern": "^(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$",
+						"flags": "u"
+					}
+				},
+				{
+					"$class": "concerto.metamodel@1.0.0.BooleanProperty",
+					"name": "isArray",
+					"isArray": false,
+					"isOptional": false,
+					"defaultValue": false
+				},
+				{
+					"$class": "concerto.metamodel@1.0.0.BooleanProperty",
+					"name": "isOptional",
+					"isArray": false,
+					"isOptional": false,
+					"defaultValue": false
+				},
+				{
+					"$class": "concerto.metamodel@1.0.0.ObjectProperty",
+					"name": "decorators",
+					"type": {
+						"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+						"name": "Decorator"
+					},
+					"isArray": true,
+					"isOptional": true
+				},
+				{
+					"$class": "concerto.metamodel@1.0.0.ObjectProperty",
+					"name": "location",
+					"type": {
+						"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+						"name": "Range"
+					},
+					"isArray": false,
+					"isOptional": true
+				}
+			]
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "RelationshipProperty",
+			"isAbstract": false,
+			"properties": [
+				{
+					"$class": "concerto.metamodel@1.0.0.ObjectProperty",
+					"name": "type",
+					"type": {
+						"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+						"name": "TypeIdentifier"
+					},
+					"isArray": false,
+					"isOptional": false
+				}
+			],
+			"superType": {
+				"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+				"name": "Property"
+			}
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "ObjectProperty",
+			"isAbstract": false,
+			"properties": [
+				{
+					"$class": "concerto.metamodel@1.0.0.StringProperty",
+					"name": "defaultValue",
+					"isArray": false,
+					"isOptional": true
+				},
+				{
+					"$class": "concerto.metamodel@1.0.0.ObjectProperty",
+					"name": "type",
+					"type": {
+						"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+						"name": "TypeIdentifier"
+					},
+					"isArray": false,
+					"isOptional": false
+				}
+			],
+			"superType": {
+				"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+				"name": "Property"
+			}
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "BooleanProperty",
+			"isAbstract": false,
+			"properties": [
+				{
+					"$class": "concerto.metamodel@1.0.0.BooleanProperty",
+					"name": "defaultValue",
+					"isArray": false,
+					"isOptional": true
+				}
+			],
+			"superType": {
+				"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+				"name": "Property"
+			}
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "DateTimeProperty",
+			"isAbstract": false,
+			"properties": [],
+			"superType": {
+				"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+				"name": "Property"
+			}
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "StringProperty",
+			"isAbstract": false,
+			"properties": [
+				{
+					"$class": "concerto.metamodel@1.0.0.StringProperty",
+					"name": "defaultValue",
+					"isArray": false,
+					"isOptional": true
+				},
+				{
+					"$class": "concerto.metamodel@1.0.0.ObjectProperty",
+					"name": "validator",
+					"type": {
+						"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+						"name": "StringRegexValidator"
+					},
+					"isArray": false,
+					"isOptional": true
+				},
+				{
+					"$class": "concerto.metamodel@1.0.0.ObjectProperty",
+					"name": "lengthValidator",
+					"type": {
+						"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+						"name": "StringLengthValidator"
+					},
+					"isArray": false,
+					"isOptional": true
+				}
+			],
+			"superType": {
+				"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+				"name": "Property"
+			}
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "StringRegexValidator",
+			"isAbstract": false,
+			"properties": [
+				{
+					"$class": "concerto.metamodel@1.0.0.StringProperty",
+					"name": "pattern",
+					"isArray": false,
+					"isOptional": false
+				},
+				{
+					"$class": "concerto.metamodel@1.0.0.StringProperty",
+					"name": "flags",
+					"isArray": false,
+					"isOptional": false
+				}
+			]
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "StringLengthValidator",
+			"isAbstract": false,
+			"properties": [
+				{
+					"$class": "concerto.metamodel@1.0.0.IntegerProperty",
+					"name": "minLength",
+					"isArray": false,
+					"isOptional": true
+				},
+				{
+					"$class": "concerto.metamodel@1.0.0.IntegerProperty",
+					"name": "maxLength",
+					"isArray": false,
+					"isOptional": true
+				}
+			]
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "DoubleProperty",
+			"isAbstract": false,
+			"properties": [
+				{
+					"$class": "concerto.metamodel@1.0.0.DoubleProperty",
+					"name": "defaultValue",
+					"isArray": false,
+					"isOptional": true
+				},
+				{
+					"$class": "concerto.metamodel@1.0.0.ObjectProperty",
+					"name": "validator",
+					"type": {
+						"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+						"name": "DoubleDomainValidator"
+					},
+					"isArray": false,
+					"isOptional": true
+				}
+			],
+			"superType": {
+				"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+				"name": "Property"
+			}
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "DoubleDomainValidator",
+			"isAbstract": false,
+			"properties": [
+				{
+					"$class": "concerto.metamodel@1.0.0.DoubleProperty",
+					"name": "lower",
+					"isArray": false,
+					"isOptional": true
+				},
+				{
+					"$class": "concerto.metamodel@1.0.0.DoubleProperty",
+					"name": "upper",
+					"isArray": false,
+					"isOptional": true
+				}
+			]
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "IntegerProperty",
+			"isAbstract": false,
+			"properties": [
+				{
+					"$class": "concerto.metamodel@1.0.0.IntegerProperty",
+					"name": "defaultValue",
+					"isArray": false,
+					"isOptional": true
+				},
+				{
+					"$class": "concerto.metamodel@1.0.0.ObjectProperty",
+					"name": "validator",
+					"type": {
+						"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+						"name": "IntegerDomainValidator"
+					},
+					"isArray": false,
+					"isOptional": true
+				}
+			],
+			"superType": {
+				"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+				"name": "Property"
+			}
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "IntegerDomainValidator",
+			"isAbstract": false,
+			"properties": [
+				{
+					"$class": "concerto.metamodel@1.0.0.IntegerProperty",
+					"name": "lower",
+					"isArray": false,
+					"isOptional": true
+				},
+				{
+					"$class": "concerto.metamodel@1.0.0.IntegerProperty",
+					"name": "upper",
+					"isArray": false,
+					"isOptional": true
+				}
+			]
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "LongProperty",
+			"isAbstract": false,
+			"properties": [
+				{
+					"$class": "concerto.metamodel@1.0.0.LongProperty",
+					"name": "defaultValue",
+					"isArray": false,
+					"isOptional": true
+				},
+				{
+					"$class": "concerto.metamodel@1.0.0.ObjectProperty",
+					"name": "validator",
+					"type": {
+						"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+						"name": "LongDomainValidator"
+					},
+					"isArray": false,
+					"isOptional": true
+				}
+			],
+			"superType": {
+				"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+				"name": "Property"
+			}
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "LongDomainValidator",
+			"isAbstract": false,
+			"properties": [
+				{
+					"$class": "concerto.metamodel@1.0.0.LongProperty",
+					"name": "lower",
+					"isArray": false,
+					"isOptional": true
+				},
+				{
+					"$class": "concerto.metamodel@1.0.0.LongProperty",
+					"name": "upper",
+					"isArray": false,
+					"isOptional": true
+				}
+			]
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "Import",
+			"isAbstract": true,
+			"properties": [
+				{
+					"$class": "concerto.metamodel@1.0.0.StringProperty",
+					"name": "namespace",
+					"isArray": false,
+					"isOptional": false
+				},
+				{
+					"$class": "concerto.metamodel@1.0.0.StringProperty",
+					"name": "uri",
+					"isArray": false,
+					"isOptional": true
+				}
+			]
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "ImportAll",
+			"isAbstract": false,
+			"properties": [],
+			"superType": {
+				"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+				"name": "Import"
+			}
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "ImportType",
+			"isAbstract": false,
+			"properties": [
+				{
+					"$class": "concerto.metamodel@1.0.0.StringProperty",
+					"name": "name",
+					"isArray": false,
+					"isOptional": false
+				}
+			],
+			"superType": {
+				"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+				"name": "Import"
+			}
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "ImportTypes",
+			"isAbstract": false,
+			"properties": [
+				{
+					"$class": "concerto.metamodel@1.0.0.StringProperty",
+					"name": "types",
+					"isArray": true,
+					"isOptional": false
+				}
+			],
+			"superType": {
+				"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+				"name": "Import"
+			}
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "Model",
+			"isAbstract": false,
+			"properties": [
+				{
+					"$class": "concerto.metamodel@1.0.0.StringProperty",
+					"name": "namespace",
+					"isArray": false,
+					"isOptional": false
+				},
+				{
+					"$class": "concerto.metamodel@1.0.0.StringProperty",
+					"name": "sourceUri",
+					"isArray": false,
+					"isOptional": true
+				},
+				{
+					"$class": "concerto.metamodel@1.0.0.StringProperty",
+					"name": "concertoVersion",
+					"isArray": false,
+					"isOptional": true
+				},
+				{
+					"$class": "concerto.metamodel@1.0.0.ObjectProperty",
+					"name": "imports",
+					"type": {
+						"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+						"name": "Import"
+					},
+					"isArray": true,
+					"isOptional": true
+				},
+				{
+					"$class": "concerto.metamodel@1.0.0.ObjectProperty",
+					"name": "declarations",
+					"type": {
 						"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
 						"name": "Declaration"
-					}
+					},
+					"isArray": true,
+					"isOptional": true
 				},
 				{
-					"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-					"name": "MapKeyType",
-					"isAbstract": false,
-					"properties": [
-						{
-							"$class": "concerto.metamodel@1.0.0.ObjectProperty",
-							"name": "type",
-							"type": {
-								"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-								"name": "TypeIdentifier"
-							},
-							"isArray": false,
-							"isOptional": false
-						},
-						{
-							"$class": "concerto.metamodel@1.0.0.ObjectProperty",
-							"name": "decorators",
-							"type": {
-								"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-								"name": "Decorator"
-							},
-							"isArray": true,
-							"isOptional": true
-						},
-						{
-							"$class": "concerto.metamodel@1.0.0.ObjectProperty",
-							"name": "location",
-							"type": {
-								"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-								"name": "Range"
-							},
-							"isArray": false,
-							"isOptional": true
-						}
-					]
-				},
-				{
-					"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-					"name": "AggregateValueType",
-					"isAbstract": false,
-					"properties": [
-						{
-							"$class": "concerto.metamodel@1.0.0.ObjectProperty",
-							"name": "type",
-							"type": {
-								"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-								"name": "TypeIdentifier"
-							},
-							"isArray": false,
-							"isOptional": false
-						},
-						{
-							"$class": "concerto.metamodel@1.0.0.ObjectProperty",
-							"name": "decorators",
-							"type": {
-								"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-								"name": "Decorator"
-							},
-							"isArray": true,
-							"isOptional": true
-						},
-						{
-							"$class": "concerto.metamodel@1.0.0.ObjectProperty",
-							"name": "location",
-							"type": {
-								"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-								"name": "Range"
-							},
-							"isArray": false,
-							"isOptional": true
-						}
-					]
-				},
-				{
-					"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-					"name": "AggregateRelationshipValueType",
-					"isAbstract": false,
-					"properties": [
-						{
-							"$class": "concerto.metamodel@1.0.0.BooleanProperty",
-							"name": "isRelationship",
-							"isArray": false,
-							"isOptional": false
-						}
-					],
-					"superType": {
+					"$class": "concerto.metamodel@1.0.0.ObjectProperty",
+					"name": "decorators",
+					"type": {
 						"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-						"name": "AggregateValueType"
-					}
+						"name": "Decorator"
+					},
+					"isArray": true,
+					"isOptional": true
+				}
+			]
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "Models",
+			"isAbstract": false,
+			"properties": [
+				{
+					"$class": "concerto.metamodel@1.0.0.ObjectProperty",
+					"name": "models",
+					"type": {
+						"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+						"name": "Model"
+					},
+					"isArray": true,
+					"isOptional": false
+				}
+			]
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "ScalarDeclaration",
+			"isAbstract": true,
+			"properties": [],
+			"superType": {
+				"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+				"name": "Declaration"
+			}
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "BooleanScalar",
+			"isAbstract": false,
+			"properties": [
+				{
+					"$class": "concerto.metamodel@1.0.0.BooleanProperty",
+					"name": "defaultValue",
+					"isArray": false,
+					"isOptional": false
+				}
+			],
+			"superType": {
+				"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+				"name": "ScalarDeclaration"
+			}
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "IntegerScalar",
+			"isAbstract": false,
+			"properties": [
+				{
+					"$class": "concerto.metamodel@1.0.0.IntegerProperty",
+					"name": "defaultValue",
+					"isArray": false,
+					"isOptional": true
 				},
-        {
-            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-            "name": "EnumDeclaration",
-            "isAbstract": false,
-            "properties": [
-                {
-                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-                    "name": "properties",
-                    "type": {
-                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                        "name": "EnumProperty"
-                    },
-                    "isArray": true,
-                    "isOptional": false
-                }
-            ],
-            "superType": {
-                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                "name": "Declaration"
-            }
-        },
-        {
-            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-            "name": "EnumProperty",
-            "isAbstract": false,
-            "properties": [
-                {
-                    "$class": "concerto.metamodel@1.0.0.StringProperty",
-                    "name": "name",
-                    "isArray": false,
-                    "isOptional": false,
-                    "validator": {
-                        "$class": "concerto.metamodel@1.0.0.StringRegexValidator",
-                        "pattern": "^(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$",
-                        "flags": "u"
-                    }
-                },
-                {
-                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-                    "name": "decorators",
-                    "type": {
-                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                        "name": "Decorator"
-                    },
-                    "isArray": true,
-                    "isOptional": true
-                },
-                {
-                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-                    "name": "location",
-                    "type": {
-                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                        "name": "Range"
-                    },
-                    "isArray": false,
-                    "isOptional": true
-                }
-            ]
-        },
-        {
-            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-            "name": "ConceptDeclaration",
-            "isAbstract": false,
-            "properties": [
-                {
-                    "$class": "concerto.metamodel@1.0.0.BooleanProperty",
-                    "name": "isAbstract",
-                    "isArray": false,
-                    "isOptional": false,
-                    "defaultValue": false
-                },
-                {
-                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-                    "name": "identified",
-                    "type": {
-                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                        "name": "Identified"
-                    },
-                    "isArray": false,
-                    "isOptional": true
-                },
-                {
-                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-                    "name": "superType",
-                    "type": {
-                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                        "name": "TypeIdentifier"
-                    },
-                    "isArray": false,
-                    "isOptional": true
-                },
-                {
-                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-                    "name": "properties",
-                    "type": {
-                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                        "name": "Property"
-                    },
-                    "isArray": true,
-                    "isOptional": false
-                }
-            ],
-            "superType": {
-                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                "name": "Declaration"
-            }
-        },
-        {
-            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-            "name": "AssetDeclaration",
-            "isAbstract": false,
-            "properties": [],
-            "superType": {
-                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                "name": "ConceptDeclaration"
-            }
-        },
-        {
-            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-            "name": "ParticipantDeclaration",
-            "isAbstract": false,
-            "properties": [],
-            "superType": {
-                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                "name": "ConceptDeclaration"
-            }
-        },
-        {
-            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-            "name": "TransactionDeclaration",
-            "isAbstract": false,
-            "properties": [],
-            "superType": {
-                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                "name": "ConceptDeclaration"
-            }
-        },
-        {
-            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-            "name": "EventDeclaration",
-            "isAbstract": false,
-            "properties": [],
-            "superType": {
-                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                "name": "ConceptDeclaration"
-            }
-        },
-        {
-            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-            "name": "Property",
-            "isAbstract": true,
-            "properties": [
-                {
-                    "$class": "concerto.metamodel@1.0.0.StringProperty",
-                    "name": "name",
-                    "isArray": false,
-                    "isOptional": false,
-                    "validator": {
-                        "$class": "concerto.metamodel@1.0.0.StringRegexValidator",
-                        "pattern": "^(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$",
-                        "flags": "u"
-                    }
-                },
-                {
-                    "$class": "concerto.metamodel@1.0.0.BooleanProperty",
-                    "name": "isArray",
-                    "isArray": false,
-                    "isOptional": false,
-                    "defaultValue": false
-                },
-                {
-                    "$class": "concerto.metamodel@1.0.0.BooleanProperty",
-                    "name": "isOptional",
-                    "isArray": false,
-                    "isOptional": false,
-                    "defaultValue": false
-                },
-                {
-                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-                    "name": "decorators",
-                    "type": {
-                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                        "name": "Decorator"
-                    },
-                    "isArray": true,
-                    "isOptional": true
-                },
-                {
-                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-                    "name": "location",
-                    "type": {
-                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                        "name": "Range"
-                    },
-                    "isArray": false,
-                    "isOptional": true
-                }
-            ]
-        },
-        {
-            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-            "name": "RelationshipProperty",
-            "isAbstract": false,
-            "properties": [
-                {
-                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-                    "name": "type",
-                    "type": {
-                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                        "name": "TypeIdentifier"
-                    },
-                    "isArray": false,
-                    "isOptional": false
-                }
-            ],
-            "superType": {
-                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                "name": "Property"
-            }
-        },
-        {
-            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-            "name": "ObjectProperty",
-            "isAbstract": false,
-            "properties": [
-                {
-                    "$class": "concerto.metamodel@1.0.0.StringProperty",
-                    "name": "defaultValue",
-                    "isArray": false,
-                    "isOptional": true
-                },
-                {
-                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-                    "name": "type",
-                    "type": {
-                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                        "name": "TypeIdentifier"
-                    },
-                    "isArray": false,
-                    "isOptional": false
-                }
-            ],
-            "superType": {
-                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                "name": "Property"
-            }
-        },
-        {
-            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-            "name": "BooleanProperty",
-            "isAbstract": false,
-            "properties": [
-                {
-                    "$class": "concerto.metamodel@1.0.0.BooleanProperty",
-                    "name": "defaultValue",
-                    "isArray": false,
-                    "isOptional": true
-                }
-            ],
-            "superType": {
-                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                "name": "Property"
-            }
-        },
-        {
-            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-            "name": "DateTimeProperty",
-            "isAbstract": false,
-            "properties": [],
-            "superType": {
-                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                "name": "Property"
-            }
-        },
-        {
-            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-            "name": "StringProperty",
-            "isAbstract": false,
-            "properties": [
-                {
-                    "$class": "concerto.metamodel@1.0.0.StringProperty",
-                    "name": "defaultValue",
-                    "isArray": false,
-                    "isOptional": true
-                },
-                {
-                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-                    "name": "validator",
-                    "type": {
-                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                        "name": "StringRegexValidator"
-                    },
-                    "isArray": false,
-                    "isOptional": true
-                },
-                {
-                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-                    "name": "lengthValidator",
-                    "type": {
-                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                        "name": "StringLengthValidator"
-                    },
-                    "isArray": false,
-                    "isOptional": true
-                }
-            ],
-            "superType": {
-                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                "name": "Property"
-            }
-        },
-        {
-            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-            "name": "StringRegexValidator",
-            "isAbstract": false,
-            "properties": [
-                {
-                    "$class": "concerto.metamodel@1.0.0.StringProperty",
-                    "name": "pattern",
-                    "isArray": false,
-                    "isOptional": false
-                },
-                {
-                    "$class": "concerto.metamodel@1.0.0.StringProperty",
-                    "name": "flags",
-                    "isArray": false,
-                    "isOptional": false
-                }
-            ]
-        },
-        {
-            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-            "name": "StringLengthValidator",
-            "isAbstract": false,
-            "properties": [
-                {
-                    "$class": "concerto.metamodel@1.0.0.IntegerProperty",
-                    "name": "minLength",
-                    "isArray": false,
-                    "isOptional": true
-                },
-                {
-                    "$class": "concerto.metamodel@1.0.0.IntegerProperty",
-                    "name": "maxLength",
-                    "isArray": false,
-                    "isOptional": true
-                }
-            ]
-        },
-        {
-            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-            "name": "DoubleProperty",
-            "isAbstract": false,
-            "properties": [
-                {
-                    "$class": "concerto.metamodel@1.0.0.DoubleProperty",
-                    "name": "defaultValue",
-                    "isArray": false,
-                    "isOptional": true
-                },
-                {
-                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-                    "name": "validator",
-                    "type": {
-                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                        "name": "DoubleDomainValidator"
-                    },
-                    "isArray": false,
-                    "isOptional": true
-                }
-            ],
-            "superType": {
-                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                "name": "Property"
-            }
-        },
-        {
-            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-            "name": "DoubleDomainValidator",
-            "isAbstract": false,
-            "properties": [
-                {
-                    "$class": "concerto.metamodel@1.0.0.DoubleProperty",
-                    "name": "lower",
-                    "isArray": false,
-                    "isOptional": true
-                },
-                {
-                    "$class": "concerto.metamodel@1.0.0.DoubleProperty",
-                    "name": "upper",
-                    "isArray": false,
-                    "isOptional": true
-                }
-            ]
-        },
-        {
-            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-            "name": "IntegerProperty",
-            "isAbstract": false,
-            "properties": [
-                {
-                    "$class": "concerto.metamodel@1.0.0.IntegerProperty",
-                    "name": "defaultValue",
-                    "isArray": false,
-                    "isOptional": true
-                },
-                {
-                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-                    "name": "validator",
-                    "type": {
-                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                        "name": "IntegerDomainValidator"
-                    },
-                    "isArray": false,
-                    "isOptional": true
-                }
-            ],
-            "superType": {
-                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                "name": "Property"
-            }
-        },
-        {
-            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-            "name": "IntegerDomainValidator",
-            "isAbstract": false,
-            "properties": [
-                {
-                    "$class": "concerto.metamodel@1.0.0.IntegerProperty",
-                    "name": "lower",
-                    "isArray": false,
-                    "isOptional": true
-                },
-                {
-                    "$class": "concerto.metamodel@1.0.0.IntegerProperty",
-                    "name": "upper",
-                    "isArray": false,
-                    "isOptional": true
-                }
-            ]
-        },
-        {
-            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-            "name": "LongProperty",
-            "isAbstract": false,
-            "properties": [
-                {
-                    "$class": "concerto.metamodel@1.0.0.LongProperty",
-                    "name": "defaultValue",
-                    "isArray": false,
-                    "isOptional": true
-                },
-                {
-                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-                    "name": "validator",
-                    "type": {
-                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                        "name": "LongDomainValidator"
-                    },
-                    "isArray": false,
-                    "isOptional": true
-                }
-            ],
-            "superType": {
-                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                "name": "Property"
-            }
-        },
-        {
-            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-            "name": "LongDomainValidator",
-            "isAbstract": false,
-            "properties": [
-                {
-                    "$class": "concerto.metamodel@1.0.0.LongProperty",
-                    "name": "lower",
-                    "isArray": false,
-                    "isOptional": true
-                },
-                {
-                    "$class": "concerto.metamodel@1.0.0.LongProperty",
-                    "name": "upper",
-                    "isArray": false,
-                    "isOptional": true
-                }
-            ]
-        },
-        {
-            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-            "name": "Import",
-            "isAbstract": true,
-            "properties": [
-                {
-                    "$class": "concerto.metamodel@1.0.0.StringProperty",
-                    "name": "namespace",
-                    "isArray": false,
-                    "isOptional": false
-                },
-                {
-                    "$class": "concerto.metamodel@1.0.0.StringProperty",
-                    "name": "uri",
-                    "isArray": false,
-                    "isOptional": true
-                }
-            ]
-        },
-        {
-            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-            "name": "ImportAll",
-            "isAbstract": false,
-            "properties": [],
-            "superType": {
-                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                "name": "Import"
-            }
-        },
-        {
-            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-            "name": "ImportType",
-            "isAbstract": false,
-            "properties": [
-                {
-                    "$class": "concerto.metamodel@1.0.0.StringProperty",
-                    "name": "name",
-                    "isArray": false,
-                    "isOptional": false
-                }
-            ],
-            "superType": {
-                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                "name": "Import"
-            }
-        },
-        {
-            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-            "name": "ImportTypes",
-            "isAbstract": false,
-            "properties": [
-                {
-                    "$class": "concerto.metamodel@1.0.0.StringProperty",
-                    "name": "types",
-                    "isArray": true,
-                    "isOptional": false
-                }
-            ],
-            "superType": {
-                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                "name": "Import"
-            }
-        },
-        {
-            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-            "name": "Model",
-            "isAbstract": false,
-            "properties": [
-                {
-                    "$class": "concerto.metamodel@1.0.0.StringProperty",
-                    "name": "namespace",
-                    "isArray": false,
-                    "isOptional": false
-                },
-                {
-                    "$class": "concerto.metamodel@1.0.0.StringProperty",
-                    "name": "sourceUri",
-                    "isArray": false,
-                    "isOptional": true
-                },
-                {
-                    "$class": "concerto.metamodel@1.0.0.StringProperty",
-                    "name": "concertoVersion",
-                    "isArray": false,
-                    "isOptional": true
-                },
-                {
-                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-                    "name": "imports",
-                    "type": {
-                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                        "name": "Import"
-                    },
-                    "isArray": true,
-                    "isOptional": true
-                },
-                {
-                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-                    "name": "declarations",
-                    "type": {
-                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                        "name": "Declaration"
-                    },
-                    "isArray": true,
-                    "isOptional": true
-                },
-                {
-                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-                    "name": "decorators",
-                    "type": {
-                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                        "name": "Decorator"
-                    },
-                    "isArray": true,
-                    "isOptional": true
-                }
-            ]
-        },
-        {
-            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-            "name": "Models",
-            "isAbstract": false,
-            "properties": [
-                {
-                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-                    "name": "models",
-                    "type": {
-                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                        "name": "Model"
-                    },
-                    "isArray": true,
-                    "isOptional": false
-                }
-            ]
-        },
-        {
-            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-            "name": "ScalarDeclaration",
-            "isAbstract": true,
-            "properties": [],
-            "superType": {
-                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                "name": "Declaration"
-            }
-        },
-        {
-            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-            "name": "BooleanScalar",
-            "isAbstract": false,
-            "properties": [
-                {
-                    "$class": "concerto.metamodel@1.0.0.BooleanProperty",
-                    "name": "defaultValue",
-                    "isArray": false,
-                    "isOptional": false
-                }
-            ],
-            "superType": {
-                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                "name": "ScalarDeclaration"
-            }
-        },
-        {
-            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-            "name": "IntegerScalar",
-            "isAbstract": false,
-            "properties": [
-                {
-                    "$class": "concerto.metamodel@1.0.0.IntegerProperty",
-                    "name": "defaultValue",
-                    "isArray": false,
-                    "isOptional": true
-                },
-                {
-                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-                    "name": "validator",
-                    "type": {
-                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                        "name": "IntegerDomainValidator"
-                    },
-                    "isArray": false,
-                    "isOptional": true
-                }
-            ],
-            "superType": {
-                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                "name": "ScalarDeclaration"
-            }
-        },
-        {
-            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-            "name": "LongScalar",
-            "isAbstract": false,
-            "properties": [
-                {
-                    "$class": "concerto.metamodel@1.0.0.LongProperty",
-                    "name": "defaultValue",
-                    "isArray": false,
-                    "isOptional": true
-                },
-                {
-                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-                    "name": "validator",
-                    "type": {
-                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                        "name": "LongDomainValidator"
-                    },
-                    "isArray": false,
-                    "isOptional": true
-                }
-            ],
-            "superType": {
-                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                "name": "ScalarDeclaration"
-            }
-        },
-        {
-            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-            "name": "DoubleScalar",
-            "isAbstract": false,
-            "properties": [
-                {
-                    "$class": "concerto.metamodel@1.0.0.DoubleProperty",
-                    "name": "defaultValue",
-                    "isArray": false,
-                    "isOptional": true
-                },
-                {
-                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-                    "name": "validator",
-                    "type": {
-                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                        "name": "DoubleDomainValidator"
-                    },
-                    "isArray": false,
-                    "isOptional": true
-                }
-            ],
-            "superType": {
-                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                "name": "ScalarDeclaration"
-            }
-        },
-        {
-            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-            "name": "StringScalar",
-            "isAbstract": false,
-            "properties": [
-                {
-                    "$class": "concerto.metamodel@1.0.0.StringProperty",
-                    "name": "defaultValue",
-                    "isArray": false,
-                    "isOptional": true
-                },
-                {
-                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-                    "name": "validator",
-                    "type": {
-                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                        "name": "StringRegexValidator"
-                    },
-                    "isArray": false,
-                    "isOptional": true
-                },
-                {
-                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-                    "name": "lengthValidator",
-                    "type": {
-                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                        "name": "StringLengthValidator"
-                    },
-                    "isArray": false,
-                    "isOptional": true
-                }
-            ],
-            "superType": {
-                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                "name": "ScalarDeclaration"
-            }
-        },
-        {
-            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-            "name": "DateTimeScalar",
-            "isAbstract": false,
-            "properties": [
-                {
-                    "$class": "concerto.metamodel@1.0.0.StringProperty",
-                    "name": "defaultValue",
-                    "isArray": false,
-                    "isOptional": true
-                }
-            ],
-            "superType": {
-                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-                "name": "ScalarDeclaration"
-            }
-        }
-    ]
+				{
+					"$class": "concerto.metamodel@1.0.0.ObjectProperty",
+					"name": "validator",
+					"type": {
+						"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+						"name": "IntegerDomainValidator"
+					},
+					"isArray": false,
+					"isOptional": true
+				}
+			],
+			"superType": {
+				"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+				"name": "ScalarDeclaration"
+			}
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "LongScalar",
+			"isAbstract": false,
+			"properties": [
+				{
+					"$class": "concerto.metamodel@1.0.0.LongProperty",
+					"name": "defaultValue",
+					"isArray": false,
+					"isOptional": true
+				},
+				{
+					"$class": "concerto.metamodel@1.0.0.ObjectProperty",
+					"name": "validator",
+					"type": {
+						"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+						"name": "LongDomainValidator"
+					},
+					"isArray": false,
+					"isOptional": true
+				}
+			],
+			"superType": {
+				"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+				"name": "ScalarDeclaration"
+			}
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "DoubleScalar",
+			"isAbstract": false,
+			"properties": [
+				{
+					"$class": "concerto.metamodel@1.0.0.DoubleProperty",
+					"name": "defaultValue",
+					"isArray": false,
+					"isOptional": true
+				},
+				{
+					"$class": "concerto.metamodel@1.0.0.ObjectProperty",
+					"name": "validator",
+					"type": {
+						"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+						"name": "DoubleDomainValidator"
+					},
+					"isArray": false,
+					"isOptional": true
+				}
+			],
+			"superType": {
+				"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+				"name": "ScalarDeclaration"
+			}
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "StringScalar",
+			"isAbstract": false,
+			"properties": [
+				{
+					"$class": "concerto.metamodel@1.0.0.StringProperty",
+					"name": "defaultValue",
+					"isArray": false,
+					"isOptional": true
+				},
+				{
+					"$class": "concerto.metamodel@1.0.0.ObjectProperty",
+					"name": "validator",
+					"type": {
+						"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+						"name": "StringRegexValidator"
+					},
+					"isArray": false,
+					"isOptional": true
+				},
+				{
+					"$class": "concerto.metamodel@1.0.0.ObjectProperty",
+					"name": "lengthValidator",
+					"type": {
+						"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+						"name": "StringLengthValidator"
+					},
+					"isArray": false,
+					"isOptional": true
+				}
+			],
+			"superType": {
+				"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+				"name": "ScalarDeclaration"
+			}
+		},
+		{
+			"$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+			"name": "DateTimeScalar",
+			"isAbstract": false,
+			"properties": [
+				{
+					"$class": "concerto.metamodel@1.0.0.StringProperty",
+					"name": "defaultValue",
+					"isArray": false,
+					"isOptional": true
+				}
+			],
+			"superType": {
+				"$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+				"name": "ScalarDeclaration"
+			}
+		}
+	]
 }


### PR DESCRIPTION
Drafting the redesign of the metamodel for a MapDeclarations Key and Value Types.


```
abstract concept MapKeyType {
  o Decorator[] decorators optional
  o Range location optional
}

abstract concept MapValueType {
  o Decorator[] decorators optional
  o Range location optional
}

concept MapDeclaration extends Declaration {
  o MapKeyType key
  o MapValueType value
}

concept StringMapKeyType extends MapKeyType {}
concept DateTimeMapKeyType extends MapKeyType {}

concept ObjectMapKeyType extends MapKeyType {
  o TypeIdentifier type
}

concept BooleanMapValueType extends MapValueType {}
concept DateTimeMapValueType extends MapValueType {}
concept StringMapValueType extends MapValueType {}
concept IntegerMapValueType extends MapValueType {}
concept LongMapValueType extends MapValueType {}
concept DoubleMapValueType extends MapValueType {}

concept ObjectMapValueType extends MapValueType {
  o TypeIdentifier type
}

concept RelationshipMapValueType extends MapValueType {
  o TypeIdentifier type
}
```