### PR TITLE
feat(map): add max keys validation facet

### DIFF
--- a/lib/metamodel.cto
+++ b/lib/metamodel.cto
@@ -82,9 +82,14 @@ abstract concept MapValueType {
   o Range location optional
 }
 
+concept MapKeyCountValidator {
+  o Integer maxKeys
+}
+
 concept MapDeclaration extends Declaration {
   o MapKeyType key
   o MapValueType value
+  o MapKeyCountValidator maxKeysValidator optional
 }
 
 concept StringMapKeyType extends MapKeyType {}

--- a/lib/metamodel.json
+++ b/lib/metamodel.json
@@ -338,6 +338,17 @@
     },
     {
       "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+      "name": "MapKeyCountValidator",
+      "isAbstract": false,
+      "properties": [{
+          "$class": "concerto.metamodel@1.0.0.IntegerProperty",
+          "name": "maxKeys",
+          "isArray": false,
+          "isOptional": false
+      }]
+    },
+    {
+      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
       "name": "MapDeclaration",
       "isAbstract": false,
       "properties": [
@@ -360,6 +371,16 @@
           },
           "isArray": false,
           "isOptional": false
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+          "name": "maxKeysValidator",
+          "type": {
+              "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+              "name": "MapKeyCountValidator"
+          },
+          "isArray": false,
+          "isOptional": true
         }
       ],
       "superType": {


### PR DESCRIPTION
# Closes #<CORRESPONDING ISSUE NUMBER>
This is to extend the metamodel in order to support a validation facet for the number of keys in a map, as mentioned in [Issue #732](https://github.com/accordproject/concerto/issues/732) (Concerto repository)

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- Add a concept `MapKeyCountValidator` to metamodel, and update `MapDeclaration` with the new concept.

### Related Issues
- [This issue](https://github.com/accordproject/concerto/issues/732) from the Concerto repo.

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Merging to `main` from `fork:branchname`
