### PR TITLE
fix(resolve): resolve namespace for decorators on primitives

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -1,0 +1,24 @@
+{
+  "$class": "concerto.metamodel@1.0.0.Model",
+  "decorators": [],
+  "namespace": "org.categories@1.0.0",
+  "imports": [],
+  "declarations": [
+    {
+      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+      "name": "Category",
+      "isAbstract": true,
+      "properties": []
+    },
+    {
+      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+      "name": "Engineering",
+      "isAbstract": false,
+      "properties": [],
+      "superType": {
+        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+        "name": "Category"
+      }
+    }
+  ]
+}

--- a/decorators.json
+++ b/decorators.json
@@ -1,0 +1,79 @@
+{
+  "$class": "concerto.metamodel@1.0.0.Model",
+  "decorators": [],
+  "namespace": "org.car@1.0.0",
+  "imports": [
+    {
+      "$class": "concerto.metamodel@1.0.0.ImportTypes",
+      "namespace": "org.categories@1.0.0",
+      "types": [
+        "Engineering"
+      ]
+    }
+  ],
+  "declarations": [
+    {
+      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+      "name": "Car",
+      "isAbstract": false,
+      "properties": [
+        {
+          "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+          "name": "part",
+          "type": {
+            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+            "name": "Part"
+          },
+          "isArray": false,
+          "isOptional": false
+        }
+      ]
+    },
+    {
+      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+      "name": "Part",
+      "isAbstract": true,
+      "properties": [
+        {
+          "$class": "concerto.metamodel@1.0.0.StringProperty",
+          "name": "name",
+          "isArray": false,
+          "isOptional": false,
+          "decorators": [
+            {
+              "$class": "concerto.metamodel@1.0.0.Decorator",
+              "name": "category",
+              "arguments": [
+                {
+                  "$class": "concerto.metamodel@1.0.0.DecoratorTypeReference",
+                  "type": {
+                    "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                    "name": "Engineering"
+                  },
+                  "isArray": false
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+      "name": "Wheel",
+      "isAbstract": false,
+      "properties": [
+        {
+          "$class": "concerto.metamodel@1.0.0.DoubleProperty",
+          "name": "diameter",
+          "isArray": false,
+          "isOptional": false
+        }
+      ],
+      "superType": {
+        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+        "name": "Part"
+      }
+    }
+  ]
+}

--- a/lib/metamodelutil.js
+++ b/lib/metamodelutil.js
@@ -126,6 +126,11 @@ function resolveName(name, table) {
  * @return {object} the metamodel with fully qualified names
  */
 function resolveTypeNames(metaModel, table) {
+    // any element can have a decorator (including primitive fields) , so lets resolve those first
+    (metaModel.decorators || []).forEach((decorator) => {
+        resolveTypeNames(decorator, table);
+    });
+
     switch (metaModel.$class) {
     case `${MetaModelNamespace}.Model`: {
         (metaModel.declarations || []).forEach((decl) => {
@@ -145,30 +150,11 @@ function resolveTypeNames(metaModel, table) {
         (metaModel.properties || []).forEach((property) => {
             resolveTypeNames(property, table);
         });
-        (metaModel.decorators || []).forEach((decorator) => {
-            resolveTypeNames(decorator, table);
-        });
-    }
-        break;
-    case `${MetaModelNamespace}.EnumDeclaration`: {
-        (metaModel.decorators || []).forEach((decorator) => {
-            resolveTypeNames(decorator, table);
-        });
     }
         break;
     case `${MetaModelNamespace}.MapDeclaration`: {
         resolveTypeNames(metaModel.key, table);
         resolveTypeNames(metaModel.value, table);
-    }
-        break;
-    case `${MetaModelNamespace}.EnumProperty`:
-    case `${MetaModelNamespace}.ObjectProperty`:
-    case `${MetaModelNamespace}.RelationshipProperty`: {
-        const name = metaModel.type.name;
-        metaModel.type.namespace = resolveName(name, table);
-        (metaModel.decorators || []).forEach((decorator) => {
-            resolveTypeNames(decorator, table);
-        });
     }
         break;
     case `${MetaModelNamespace}.Decorator`: {
@@ -177,17 +163,13 @@ function resolveTypeNames(metaModel, table) {
         });
     }
         break;
-    case `${MetaModelNamespace}.DecoratorTypeReference`: {
-        const name = metaModel.type.name;
-        metaModel.type.namespace = resolveName(name, table);
-    }
-        break;
+    case `${MetaModelNamespace}.EnumProperty`:
+    case `${MetaModelNamespace}.ObjectProperty`:
+    case `${MetaModelNamespace}.RelationshipProperty`:
+    case `${MetaModelNamespace}.DecoratorTypeReference`:
     case `${MetaModelNamespace}.ObjectMapKeyType`:
     case `${MetaModelNamespace}.ObjectMapValueType`: {
         metaModel.type.namespace = resolveName(metaModel.type.name, table);
-        (metaModel.decorators || []).forEach((decorator) => {
-            resolveTypeNames(decorator, table);
-        });
     }
         break;
     case `${MetaModelNamespace}.StringScalar`:
@@ -197,9 +179,6 @@ function resolveTypeNames(metaModel, table) {
     case `${MetaModelNamespace}.LongScalar`:
     case `${MetaModelNamespace}.IntegerScalar`: {
         metaModel.namespace = resolveName(metaModel.name, table);
-        (metaModel.decorators || []).forEach((decorator) => {
-            resolveTypeNames(decorator, table);
-        });
     }
         break;
     }

--- a/test/cto/categories.cto
+++ b/test/cto/categories.cto
@@ -1,0 +1,4 @@
+namespace org.categories@1.0.0
+
+abstract concept Category {}
+concept Engineering extends Category {}

--- a/test/cto/decorators.cto
+++ b/test/cto/decorators.cto
@@ -1,0 +1,16 @@
+namespace org.car@1.0.0
+
+import org.categories@1.0.0.{Engineering}
+
+concept Car {
+  o Part part
+}
+
+abstract concept Part {
+  @category(Engineering)
+  o String name 
+}
+
+concept Wheel extends Part {
+  o Double diameter
+}

--- a/test/cto/decorators.json
+++ b/test/cto/decorators.json
@@ -1,0 +1,108 @@
+{
+  "$class": "concerto.metamodel@1.0.0.Models",
+  "models": [
+    {
+      "$class": "concerto.metamodel@1.0.0.Model",
+      "decorators": [],
+      "namespace": "org.categories@1.0.0",
+      "imports": [],
+      "declarations": [
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "name": "Category",
+          "isAbstract": true,
+          "properties": []
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "name": "Engineering",
+          "isAbstract": false,
+          "properties": [],
+          "superType": {
+            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+            "name": "Category"
+          }
+        }
+      ]
+    },
+    {
+      "$class": "concerto.metamodel@1.0.0.Model",
+      "decorators": [],
+      "namespace": "org.car@1.0.0",
+      "imports": [
+        {
+          "$class": "concerto.metamodel@1.0.0.ImportTypes",
+          "namespace": "org.categories@1.0.0",
+          "types": [
+            "Engineering"
+          ]
+        }
+      ],
+      "declarations": [
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "name": "Car",
+          "isAbstract": false,
+          "properties": [
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "name": "part",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "Part"
+              },
+              "isArray": false,
+              "isOptional": false
+            }
+          ]
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "name": "Part",
+          "isAbstract": true,
+          "properties": [
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "name": "name",
+              "isArray": false,
+              "isOptional": false,
+              "decorators": [
+                {
+                  "$class": "concerto.metamodel@1.0.0.Decorator",
+                  "name": "category",
+                  "arguments": [
+                    {
+                      "$class": "concerto.metamodel@1.0.0.DecoratorTypeReference",
+                      "type": {
+                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                        "name": "Engineering"
+                      },
+                      "isArray": false
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "name": "Wheel",
+          "isAbstract": false,
+          "properties": [
+            {
+              "$class": "concerto.metamodel@1.0.0.DoubleProperty",
+              "name": "diameter",
+              "isArray": false,
+              "isOptional": false
+            }
+          ],
+          "superType": {
+            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+            "name": "Part"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/cto/decoratorsResolved.json
+++ b/test/cto/decoratorsResolved.json
@@ -1,0 +1,112 @@
+{
+  "$class": "concerto.metamodel@1.0.0.Models",
+  "models": [
+    {
+      "$class": "concerto.metamodel@1.0.0.Model",
+      "decorators": [],
+      "namespace": "org.categories@1.0.0",
+      "imports": [],
+      "declarations": [
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "name": "Category",
+          "isAbstract": true,
+          "properties": []
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "name": "Engineering",
+          "isAbstract": false,
+          "properties": [],
+          "superType": {
+            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+            "name": "Category",
+            "namespace": "org.categories@1.0.0"
+          }
+        }
+      ]
+    },
+    {
+      "$class": "concerto.metamodel@1.0.0.Model",
+      "decorators": [],
+      "namespace": "org.car@1.0.0",
+      "imports": [
+        {
+          "$class": "concerto.metamodel@1.0.0.ImportTypes",
+          "namespace": "org.categories@1.0.0",
+          "types": [
+            "Engineering"
+          ]
+        }
+      ],
+      "declarations": [
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "name": "Car",
+          "isAbstract": false,
+          "properties": [
+            {
+              "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+              "name": "part",
+              "type": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "Part",
+                "namespace": "org.car@1.0.0"
+              },
+              "isArray": false,
+              "isOptional": false
+            }
+          ]
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "name": "Part",
+          "isAbstract": true,
+          "properties": [
+            {
+              "$class": "concerto.metamodel@1.0.0.StringProperty",
+              "name": "name",
+              "isArray": false,
+              "isOptional": false,
+              "decorators": [
+                {
+                  "$class": "concerto.metamodel@1.0.0.Decorator",
+                  "name": "category",
+                  "arguments": [
+                    {
+                      "$class": "concerto.metamodel@1.0.0.DecoratorTypeReference",
+                      "type": {
+                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                        "name": "Engineering",
+                        "namespace": "org.categories@1.0.0"
+                      },
+                      "isArray": false
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+          "name": "Wheel",
+          "isAbstract": false,
+          "properties": [
+            {
+              "$class": "concerto.metamodel@1.0.0.DoubleProperty",
+              "name": "diameter",
+              "isArray": false,
+              "isOptional": false
+            }
+          ],
+          "superType": {
+            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+            "name": "Part",
+            "namespace": "org.car@1.0.0"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/metamodelutil.js
+++ b/test/metamodelutil.js
@@ -100,6 +100,20 @@ describe('MetaModel (Car)', () => {
     });
 });
 
+describe('MetaModel (Decorators)', () => {
+    const decoratorsPath = path.resolve(__dirname, './cto/decorators.json');
+    const decoratorsModel = JSON.parse(fs.readFileSync(decoratorsPath, 'utf8'));
+    const decoratorsModelResolved = JSON.parse(fs.readFileSync(path.resolve(__dirname, './cto/decoratorsResolved.json'), 'utf8'));
+
+    describe('#toMetaModel', () => {
+        it('should convert a CTO model to its metamodel with name resolution', async () => {
+            const resolved = MetaModelUtil.resolveLocalNamesForAll(decoratorsModel);
+            resolved.should.deep.equal(decoratorsModelResolved);
+        });
+    });
+});
+
+
 describe('MetaModel  aliasing', () => {
 
     it('should convert a CTO model to its metamodel with name resolution', async () => {


### PR DESCRIPTION
### Changes
- Fixes the `resolveLocalNamesForAll` method to also resolve the namespace for decorators on primitive properties of declarations

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- <ONE>
- <TWO>

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Related Issues
- Issue #<NUMBER>
- Pull Request #<NUMBER>

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
