### PR TITLE
fix(metamodel): throw on null or missing  in resolveTypeNames

### DIFF
--- a/lib/metamodelutil.js
+++ b/lib/metamodelutil.js
@@ -191,6 +191,11 @@ function resolveTypeNames(metaModel, table) {
         metaModel.name = table[metaModel.name].name;
     }
         break;
+    default: {
+        if (!metaModel.$class) {
+            throw new Error(`Unrecognized $class ${String(metaModel.$class)}`);
+        }
+    }
     }
     return metaModel;
 }

--- a/test/metamodelutil.js
+++ b/test/metamodelutil.js
@@ -468,4 +468,36 @@ describe('resolveTypeNames (null $class rejection)', () => {
         (() => MetaModelUtil.resolveLocalNames(priorModels, metaModel))
             .should.throw(/Unrecognized \$class/);
     });
+
+    it('should pass through for non-empty $class that does not need resolution', () => {
+        const priorModels = {
+            $class: 'concerto.metamodel@1.0.0.Models',
+            models: []
+        };
+        const metaModel = {
+            $class: 'concerto.metamodel@1.0.0.Model',
+            namespace: 'test6@1.0.0',
+            imports: [],
+            declarations: [
+                {
+                    $class: 'concerto.metamodel@1.0.0.ConceptDeclaration',
+                    name: 'Thing',
+                    isAbstract: false,
+                    properties: [
+                        {
+                            $class: 'concerto.metamodel@1.0.0.StringProperty',
+                            name: 'label',
+                            isArray: false,
+                            isOptional: false
+                        }
+                    ]
+                }
+            ]
+        };
+
+        const resolved = MetaModelUtil.resolveLocalNames(priorModels, metaModel);
+
+        resolved.declarations[0].properties[0].$class.should.equal('concerto.metamodel@1.0.0.StringProperty');
+        resolved.declarations[0].properties[0].name.should.equal('label');
+    });
 });

--- a/test/metamodelutil.js
+++ b/test/metamodelutil.js
@@ -303,3 +303,169 @@ describe('getExternalImports', () => {
         result.should.eql({'test.*':'https://dummyURI'});
     });
 });
+
+describe('resolveTypeNames (null $class rejection)', () => {
+    it('should throw for null $class on decorator nodes', () => {
+        const priorModels = {
+            $class: 'concerto.metamodel@1.0.0.Models',
+            models: []
+        };
+        const metaModel = {
+            $class: 'concerto.metamodel@1.0.0.Model',
+            namespace: 'test@1.0.0',
+            imports: [],
+            declarations: [
+                {
+                    $class: 'concerto.metamodel@1.0.0.ConceptDeclaration',
+                    name: 'TestConcept',
+                    isAbstract: false,
+                    properties: [],
+                    decorators: [
+                        {
+                            $class: null,
+                            name: 'AnotherDecorator',
+                            arguments: []
+                        }
+                    ]
+                }
+            ]
+        };
+
+        (() => MetaModelUtil.resolveLocalNames(priorModels, metaModel))
+            .should.throw(/Unrecognized \$class/);
+    });
+
+    it('should throw for undefined $class on decorator nodes', () => {
+        const priorModels = {
+            $class: 'concerto.metamodel@1.0.0.Models',
+            models: []
+        };
+        const metaModel = {
+            $class: 'concerto.metamodel@1.0.0.Model',
+            namespace: 'test2@1.0.0',
+            imports: [],
+            declarations: [
+                {
+                    $class: 'concerto.metamodel@1.0.0.ConceptDeclaration',
+                    name: 'TestConcept',
+                    isAbstract: false,
+                    properties: [],
+                    decorators: [
+                        {
+                            name: 'MissingClassDecorator',
+                            arguments: []
+                        }
+                    ]
+                }
+            ]
+        };
+
+        (() => MetaModelUtil.resolveLocalNames(priorModels, metaModel))
+            .should.throw(/Unrecognized \$class/);
+    });
+
+    it('should throw for null $class on declaration nodes', () => {
+        const priorModels = {
+            $class: 'concerto.metamodel@1.0.0.Models',
+            models: [{
+                $class: 'concerto.metamodel@1.0.0.Model',
+                namespace: 'dep@1.0.0',
+                imports: [],
+                declarations: [{
+                    $class: 'concerto.metamodel@1.0.0.ConceptDeclaration',
+                    name: 'Base',
+                    isAbstract: true,
+                    properties: []
+                }]
+            }]
+        };
+        const metaModel = {
+            $class: 'concerto.metamodel@1.0.0.Model',
+            namespace: 'test3@1.0.0',
+            imports: [{ $class: 'concerto.metamodel@1.0.0.ImportAll', namespace: 'dep@1.0.0' }],
+            declarations: [
+                {
+                    $class: null,
+                    name: 'Child',
+                    isAbstract: false,
+                    superType: { $class: 'concerto.metamodel@1.0.0.TypeIdentifier', name: 'Base' },
+                    properties: []
+                }
+            ]
+        };
+
+        (() => MetaModelUtil.resolveLocalNames(priorModels, metaModel))
+            .should.throw(/Unrecognized \$class/);
+    });
+
+    it('should throw for null $class on property nodes', () => {
+        const priorModels = {
+            $class: 'concerto.metamodel@1.0.0.Models',
+            models: [{
+                $class: 'concerto.metamodel@1.0.0.Model',
+                namespace: 'dep@1.0.0',
+                imports: [],
+                declarations: [{
+                    $class: 'concerto.metamodel@1.0.0.ConceptDeclaration',
+                    name: 'Address',
+                    isAbstract: false,
+                    properties: []
+                }]
+            }]
+        };
+        const metaModel = {
+            $class: 'concerto.metamodel@1.0.0.Model',
+            namespace: 'test4@1.0.0',
+            imports: [{ $class: 'concerto.metamodel@1.0.0.ImportAll', namespace: 'dep@1.0.0' }],
+            declarations: [
+                {
+                    $class: 'concerto.metamodel@1.0.0.ConceptDeclaration',
+                    name: 'Person',
+                    isAbstract: false,
+                    properties: [
+                        {
+                            $class: null,
+                            name: 'address',
+                            isArray: false,
+                            isOptional: false,
+                            type: {
+                                $class: 'concerto.metamodel@1.0.0.TypeIdentifier',
+                                name: 'Address'
+                            }
+                        }
+                    ]
+                }
+            ]
+        };
+
+        (() => MetaModelUtil.resolveLocalNames(priorModels, metaModel))
+            .should.throw(/Unrecognized \$class/);
+    });
+
+    it('should throw for null $class on MapDeclaration nodes', () => {
+        const priorModels = {
+            $class: 'concerto.metamodel@1.0.0.Models',
+            models: []
+        };
+        const metaModel = {
+            $class: 'concerto.metamodel@1.0.0.Model',
+            namespace: 'test5@1.0.0',
+            imports: [],
+            declarations: [
+                {
+                    $class: null,
+                    name: 'MyMap',
+                    key: {
+                        $class: 'concerto.metamodel@1.0.0.StringMapKeyType'
+                    },
+                    value: {
+                        $class: 'concerto.metamodel@1.0.0.StringMapValueType'
+                    }
+                }
+            ]
+        };
+
+        (() => MetaModelUtil.resolveLocalNames(priorModels, metaModel))
+            .should.throw(/Unrecognized \$class/);
+    });
+});


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #<CORRESPONDING ISSUE NUMBER>
<!--- Provide an overall summary of the pull request -->

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
`resolveTypeNames` silently skipped nodes with `$class: null` or `undefined` — the switch statement simply fell through with no match and returned a partially-resolved model

- Added a `default` case that throws `Unrecognized $class` when `$class` is falsy

### Related Issues
- Issue #<NUMBER>
- Pull Request #<NUMBER>

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
