### PR TITLE
feat(metamodel): generate metamodel.json from CTO in build step

### DIFF
--- a/genmetamodel.js
+++ b/genmetamodel.js
@@ -46,3 +46,8 @@ module.exports = metaModelCto;
 `;
 const metaModelJsPath = path.resolve(__dirname, 'lib', 'metamodel.js');
 fs.writeFileSync(metaModelJsPath, metaModelJs, 'utf-8');
+
+const { Parser } = require('@accordproject/concerto-cto');
+const metaModelAst = Parser.parse(metaModelCto, 'metamodel.cto', { skipLocationNodes: true });
+const metaModelJsonPath = path.resolve(__dirname, 'lib', 'metamodel.json');
+fs.writeFileSync(metaModelJsonPath, JSON.stringify(metaModelAst, null, 2) + '\n', 'utf-8');

--- a/lib/metamodel.json
+++ b/lib/metamodel.json
@@ -86,13 +86,13 @@
         },
         {
           "$class": "concerto.metamodel@1.0.0.StringProperty",
-          "name": "resolvedName",
+          "name": "namespace",
           "isArray": false,
           "isOptional": true
         },
         {
           "$class": "concerto.metamodel@1.0.0.StringProperty",
-          "name": "namespace",
+          "name": "resolvedName",
           "isArray": false,
           "isOptional": true
         }
@@ -695,6 +695,16 @@
         },
         {
           "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+          "name": "sizeValidator",
+          "type": {
+            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+            "name": "CollectionSizeValidator"
+          },
+          "isArray": false,
+          "isOptional": true
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.ObjectProperty",
           "name": "decorators",
           "type": {
             "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
@@ -710,6 +720,25 @@
             "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
             "name": "Range"
           },
+          "isArray": false,
+          "isOptional": true
+        }
+      ]
+    },
+    {
+      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+      "name": "CollectionSizeValidator",
+      "isAbstract": false,
+      "properties": [
+        {
+          "$class": "concerto.metamodel@1.0.0.IntegerProperty",
+          "name": "minSize",
+          "isArray": false,
+          "isOptional": true
+        },
+        {
+          "$class": "concerto.metamodel@1.0.0.IntegerProperty",
+          "name": "maxSize",
           "isArray": false,
           "isOptional": true
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,9 @@
       "version": "3.15.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@accordproject/concerto-codegen": "4.1.1",
-        "@accordproject/concerto-core": "4.1.2",
+        "@accordproject/concerto-codegen": "5.1.0",
+        "@accordproject/concerto-core": "4.1.5",
+        "@accordproject/concerto-cto": "4.1.5",
         "@types/webgl-ext": "0.0.37",
         "chai": "4.3.6",
         "chai-things": "0.2.0",
@@ -57,9 +58,9 @@
       }
     },
     "node_modules/@accordproject/concerto-codegen": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-codegen/-/concerto-codegen-4.1.1.tgz",
-      "integrity": "sha512-1fKBd0AnYCPwgDcKun7hUA6rUPL2i7HsCeMRlyqyB9C5aI91khWTxx5DErLfojF/1pDmdPf2R1lPIJlKg88raQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-codegen/-/concerto-codegen-5.1.0.tgz",
+      "integrity": "sha512-9Urza9BCMG2iddKPMkDiqwbbqbfkhSYOp13c+alIB7HvqlRhjY4IGudKGMCL+V6Cs/vnwOh8H1ZsvSzbtYGZbw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -77,9 +78,9 @@
         "npm": ">=6"
       },
       "peerDependencies": {
-        "@accordproject/concerto-core": "^4.1.2",
-        "@accordproject/concerto-util": "^4.1.2",
-        "@accordproject/concerto-vocabulary": "^4.1.2"
+        "@accordproject/concerto-core": "^4.1.3",
+        "@accordproject/concerto-util": "^4.1.3",
+        "@accordproject/concerto-vocabulary": "^4.1.3"
       }
     },
     "node_modules/@accordproject/concerto-codegen/node_modules/ajv": {
@@ -138,15 +139,15 @@
       "license": "MIT"
     },
     "node_modules/@accordproject/concerto-core": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-4.1.2.tgz",
-      "integrity": "sha512-2k5J4Rwb50DZQwdMS1hQMNwHMqtETTjkqSjVXYopemzNjYdlGAF+6FrRl2cC7zfxIffiQbd0FJPbE0bDJ0mf+A==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-4.1.5.tgz",
+      "integrity": "sha512-flbKeQXK0ByjPbXZ7cG0Ef7u0TGHzW8ZoUMqEy1TJrDhJLwwYCQz6fqT6bv2L/AiiGFOT4jNvIOHTobknPT/0g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-cto": "4.1.2",
+        "@accordproject/concerto-cto": "4.1.5",
         "@accordproject/concerto-metamodel": "^3.13.0",
-        "@accordproject/concerto-util": "4.1.2",
+        "@accordproject/concerto-util": "4.1.5",
         "dayjs": "1.11.13",
         "debug": "4.3.7",
         "lorem-ipsum": "2.0.8",
@@ -160,35 +161,6 @@
       "engines": {
         "node": ">=18",
         "npm": ">=9"
-      }
-    },
-    "node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-cto": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-4.1.2.tgz",
-      "integrity": "sha512-oidSD2YC26YRiuEUctgYhIN2HMnNRA4TH/rTvMdmLUJasfD947TYCh4XwtJ4YNcjpRy80TRmCwcup7O/CIQ0vA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@accordproject/concerto-metamodel": "^3.13.0",
-        "@accordproject/concerto-util": "4.1.2",
-        "acorn": "^8.15.0",
-        "path-browserify": "^1.0.1",
-        "schema-utils": "^4.3.3"
-      },
-      "engines": {
-        "node": ">=18",
-        "npm": ">=9"
-      }
-    },
-    "node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-metamodel": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.13.0.tgz",
-      "integrity": "sha512-BkWJLYvWkDAG1lPgEr0T/4IqhjqEqzMVxAfFdJzDH3lxfEJsZ+bVJZzdcsHZUubuO0SsoahuHSs4j2Cv7DQ+Lw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6"
       }
     },
     "node_modules/@accordproject/concerto-core/node_modules/uuid": {
@@ -205,10 +177,39 @@
         "uuid": "dist/esm/bin/uuid"
       }
     },
+    "node_modules/@accordproject/concerto-cto": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-4.1.5.tgz",
+      "integrity": "sha512-rRNLTHv0s6dH2YGEruLeT1gQi3ySkkkGn8Al/xry9BEDp0AavgIWBPTIfgRSklRH9Rrn01/V2gmO6g+10ByL9g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@accordproject/concerto-metamodel": "^3.13.0",
+        "@accordproject/concerto-util": "4.1.5",
+        "acorn": "^8.15.0",
+        "path-browserify": "^1.0.1",
+        "schema-utils": "^4.3.3"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=9"
+      }
+    },
+    "node_modules/@accordproject/concerto-metamodel": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.15.0.tgz",
+      "integrity": "sha512-VAF9JWaBy5SyS8qVRGhtJsxu5xpIulTb77AppRGE7InvxStHtgk5Ni/oorh0xTcY1s5Q3G2NljkUzTShSQcXgA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6"
+      }
+    },
     "node_modules/@accordproject/concerto-util": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-4.1.2.tgz",
-      "integrity": "sha512-pHtZuWDrLXuNLrpyGaoRKcSW5fBZyrnz9IQ27aNnQt+JLSTovQzkw/JHuPUSi9EWZBC1/Ak/yUCiDpLjHfV1Dg==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-4.1.5.tgz",
+      "integrity": "sha512-9wBw9XjiNql9CMajfC2GJORUKHhh6E+ZJod2zjw1ItrvFQQaKt80T3SgzBlZ6XG/wEfgFqyypyU0XwLYGlUy+g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -241,9 +242,9 @@
       }
     },
     "node_modules/@accordproject/concerto-vocabulary": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-vocabulary/-/concerto-vocabulary-4.1.2.tgz",
-      "integrity": "sha512-B4rqccN6kssdtj36jZN1J4f75tQEa3vtRcGtIdvkGnmTmrz9GPrJZvSs8au1iLK8c+TB8z2Jb/GvVO5zc7jiyw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-vocabulary/-/concerto-vocabulary-4.1.5.tgz",
+      "integrity": "sha512-YYMWMuZrljx3N20+2QXiaPf5QIPDJweT+FxusdWvJpPPc4SGpbiK0+SdWtUhUZGkfef+E+Zmi19pBQWSuQh85w==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -254,18 +255,6 @@
       "engines": {
         "node": ">=18",
         "npm": ">=9"
-      }
-    },
-    "node_modules/@accordproject/concerto-vocabulary/node_modules/@accordproject/concerto-metamodel": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.13.0.tgz",
-      "integrity": "sha512-BkWJLYvWkDAG1lPgEr0T/4IqhjqEqzMVxAfFdJzDH3lxfEJsZ+bVJZzdcsHZUubuO0SsoahuHSs4j2Cv7DQ+Lw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6"
       }
     },
     "node_modules/@accordproject/concerto-vocabulary/node_modules/yaml": {
@@ -5257,9 +5246,9 @@
   },
   "dependencies": {
     "@accordproject/concerto-codegen": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-codegen/-/concerto-codegen-4.1.1.tgz",
-      "integrity": "sha512-1fKBd0AnYCPwgDcKun7hUA6rUPL2i7HsCeMRlyqyB9C5aI91khWTxx5DErLfojF/1pDmdPf2R1lPIJlKg88raQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-codegen/-/concerto-codegen-5.1.0.tgz",
+      "integrity": "sha512-9Urza9BCMG2iddKPMkDiqwbbqbfkhSYOp13c+alIB7HvqlRhjY4IGudKGMCL+V6Cs/vnwOh8H1ZsvSzbtYGZbw==",
       "dev": true,
       "requires": {
         "@openapi-contrib/openapi-schema-to-json-schema": "4.0.0",
@@ -5308,14 +5297,14 @@
       }
     },
     "@accordproject/concerto-core": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-4.1.2.tgz",
-      "integrity": "sha512-2k5J4Rwb50DZQwdMS1hQMNwHMqtETTjkqSjVXYopemzNjYdlGAF+6FrRl2cC7zfxIffiQbd0FJPbE0bDJ0mf+A==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-4.1.5.tgz",
+      "integrity": "sha512-flbKeQXK0ByjPbXZ7cG0Ef7u0TGHzW8ZoUMqEy1TJrDhJLwwYCQz6fqT6bv2L/AiiGFOT4jNvIOHTobknPT/0g==",
       "dev": true,
       "requires": {
-        "@accordproject/concerto-cto": "4.1.2",
+        "@accordproject/concerto-cto": "4.1.5",
         "@accordproject/concerto-metamodel": "^3.13.0",
-        "@accordproject/concerto-util": "4.1.2",
+        "@accordproject/concerto-util": "4.1.5",
         "dayjs": "1.11.13",
         "debug": "4.3.7",
         "lorem-ipsum": "2.0.8",
@@ -5327,25 +5316,6 @@
         "yaml": "^2.8.3"
       },
       "dependencies": {
-        "@accordproject/concerto-cto": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-4.1.2.tgz",
-          "integrity": "sha512-oidSD2YC26YRiuEUctgYhIN2HMnNRA4TH/rTvMdmLUJasfD947TYCh4XwtJ4YNcjpRy80TRmCwcup7O/CIQ0vA==",
-          "dev": true,
-          "requires": {
-            "@accordproject/concerto-metamodel": "^3.13.0",
-            "@accordproject/concerto-util": "4.1.2",
-            "acorn": "^8.15.0",
-            "path-browserify": "^1.0.1",
-            "schema-utils": "^4.3.3"
-          }
-        },
-        "@accordproject/concerto-metamodel": {
-          "version": "3.13.0",
-          "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.13.0.tgz",
-          "integrity": "sha512-BkWJLYvWkDAG1lPgEr0T/4IqhjqEqzMVxAfFdJzDH3lxfEJsZ+bVJZzdcsHZUubuO0SsoahuHSs4j2Cv7DQ+Lw==",
-          "dev": true
-        },
         "uuid": {
           "version": "11.0.3",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.3.tgz",
@@ -5354,10 +5324,29 @@
         }
       }
     },
+    "@accordproject/concerto-cto": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-4.1.5.tgz",
+      "integrity": "sha512-rRNLTHv0s6dH2YGEruLeT1gQi3ySkkkGn8Al/xry9BEDp0AavgIWBPTIfgRSklRH9Rrn01/V2gmO6g+10ByL9g==",
+      "dev": true,
+      "requires": {
+        "@accordproject/concerto-metamodel": "^3.13.0",
+        "@accordproject/concerto-util": "4.1.5",
+        "acorn": "^8.15.0",
+        "path-browserify": "^1.0.1",
+        "schema-utils": "^4.3.3"
+      }
+    },
+    "@accordproject/concerto-metamodel": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.15.0.tgz",
+      "integrity": "sha512-VAF9JWaBy5SyS8qVRGhtJsxu5xpIulTb77AppRGE7InvxStHtgk5Ni/oorh0xTcY1s5Q3G2NljkUzTShSQcXgA==",
+      "dev": true
+    },
     "@accordproject/concerto-util": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-4.1.2.tgz",
-      "integrity": "sha512-pHtZuWDrLXuNLrpyGaoRKcSW5fBZyrnz9IQ27aNnQt+JLSTovQzkw/JHuPUSi9EWZBC1/Ak/yUCiDpLjHfV1Dg==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-4.1.5.tgz",
+      "integrity": "sha512-9wBw9XjiNql9CMajfC2GJORUKHhh6E+ZJod2zjw1ItrvFQQaKt80T3SgzBlZ6XG/wEfgFqyypyU0XwLYGlUy+g==",
       "dev": true,
       "requires": {
         "@supercharge/promise-pool": "1.7.0",
@@ -5378,9 +5367,9 @@
       }
     },
     "@accordproject/concerto-vocabulary": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-vocabulary/-/concerto-vocabulary-4.1.2.tgz",
-      "integrity": "sha512-B4rqccN6kssdtj36jZN1J4f75tQEa3vtRcGtIdvkGnmTmrz9GPrJZvSs8au1iLK8c+TB8z2Jb/GvVO5zc7jiyw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-vocabulary/-/concerto-vocabulary-4.1.5.tgz",
+      "integrity": "sha512-YYMWMuZrljx3N20+2QXiaPf5QIPDJweT+FxusdWvJpPPc4SGpbiK0+SdWtUhUZGkfef+E+Zmi19pBQWSuQh85w==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -5388,13 +5377,6 @@
         "yaml": "2.8.3"
       },
       "dependencies": {
-        "@accordproject/concerto-metamodel": {
-          "version": "3.13.0",
-          "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.13.0.tgz",
-          "integrity": "sha512-BkWJLYvWkDAG1lPgEr0T/4IqhjqEqzMVxAfFdJzDH3lxfEJsZ+bVJZzdcsHZUubuO0SsoahuHSs4j2Cv7DQ+Lw==",
-          "dev": true,
-          "peer": true
-        },
         "yaml": {
           "version": "2.8.3",
           "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "author": "accordproject.org",
   "browserslist": "> 0.25%, not dead",
   "devDependencies": {
-    "@accordproject/concerto-core": "4.1.2",
-    "@accordproject/concerto-codegen": "4.1.1",
+    "@accordproject/concerto-core": "4.1.5",
+    "@accordproject/concerto-cto": "4.1.5",
+    "@accordproject/concerto-codegen": "5.1.0",
     "@types/webgl-ext": "0.0.37",
     "chai": "4.3.6",
     "chai-things": "0.2.0",

--- a/scripts/codegen.js
+++ b/scripts/codegen.js
@@ -20,7 +20,7 @@ const EXTRA_EXPORTS = [
  */
 async function main() {
     const metaModelCto = fs.readFileSync(path.resolve(__dirname, '..', 'lib', 'metamodel.cto'), 'utf-8');
-    const modelManager = new ModelManager({ strict: true });
+    const modelManager = new ModelManager();
     modelManager.addCTOModel(metaModelCto, 'metamodel.cto');
     const visitor = new TypescriptVisitor();
 

--- a/scripts/codegen.js
+++ b/scripts/codegen.js
@@ -19,7 +19,9 @@ const EXTRA_EXPORTS = [
  * Generate TypeScript files from the metamodel.
  */
 async function main() {
-    const modelManager = new ModelManager({addMetamodel:true, strict: true});
+    const metaModelCto = fs.readFileSync(path.resolve(__dirname, '..', 'lib', 'metamodel.cto'), 'utf-8');
+    const modelManager = new ModelManager({ strict: true });
+    modelManager.addCTOModel(metaModelCto, 'metamodel.cto');
     const visitor = new TypescriptVisitor();
 
     const fileWriter = new FileWriter(path.resolve(__dirname, '..', 'types', 'lib'));

--- a/types/lib/concerto.metamodel@1.0.0.ts
+++ b/types/lib/concerto.metamodel@1.0.0.ts
@@ -37,8 +37,8 @@ export interface IRange extends IConcept {
 
 export interface ITypeIdentifier extends IConcept {
    name: string;
-   resolvedName?: string;
    namespace?: string;
+   resolvedName?: string;
 }
 
 export interface IDecoratorLiteral extends IConcept {
@@ -195,6 +195,7 @@ export interface IProperty extends IConcept {
    name: string;
    isArray: boolean;
    isOptional: boolean;
+   sizeValidator?: ICollectionSizeValidator;
    decorators?: IDecorator[];
    location?: IRange;
 }
@@ -207,6 +208,11 @@ IStringProperty |
 IDoubleProperty | 
 IIntegerProperty | 
 ILongProperty;
+
+export interface ICollectionSizeValidator extends IConcept {
+   minSize?: number;
+   maxSize?: number;
+}
 
 export interface IRelationshipProperty extends IProperty {
    type: ITypeIdentifier;

--- a/types/lib/concerto@1.0.0.ts
+++ b/types/lib/concerto@1.0.0.ts
@@ -16,6 +16,7 @@ import type {
 	IMapValueType,
 	IEnumProperty,
 	IProperty,
+	ICollectionSizeValidator,
 	IStringRegexValidator,
 	IStringLengthValidator,
 	IDoubleDomainValidator,
@@ -43,6 +44,7 @@ IMapKeyType |
 IMapValueType | 
 IEnumProperty | 
 IProperty | 
+ICollectionSizeValidator | 
 IStringRegexValidator | 
 IStringLengthValidator | 
 IDoubleDomainValidator | 

--- a/types/lib/unions/concerto.metamodel@1.0.0.ts
+++ b/types/lib/unions/concerto.metamodel@1.0.0.ts
@@ -37,8 +37,8 @@ export interface IRange extends IConcept {
 
 export interface ITypeIdentifier extends IConcept {
    name: string;
-   resolvedName?: string;
    namespace?: string;
+   resolvedName?: string;
 }
 
 export interface IDecoratorLiteral extends IConcept {
@@ -195,6 +195,7 @@ export interface IProperty extends IConcept {
    name: string;
    isArray: boolean;
    isOptional: boolean;
+   sizeValidator?: ICollectionSizeValidator;
    decorators?: IDecorator[];
    location?: IRange;
 }
@@ -207,6 +208,11 @@ IStringProperty |
 IDoubleProperty | 
 IIntegerProperty | 
 ILongProperty;
+
+export interface ICollectionSizeValidator extends IConcept {
+   minSize?: number;
+   maxSize?: number;
+}
 
 export interface IRelationshipProperty extends IProperty {
    type: ITypeIdentifier;

--- a/types/lib/unions/concerto@1.0.0.ts
+++ b/types/lib/unions/concerto@1.0.0.ts
@@ -16,6 +16,7 @@ import type {
 	IMapValueType,
 	IEnumProperty,
 	IProperty,
+	ICollectionSizeValidator,
 	IStringRegexValidator,
 	IStringLengthValidator,
 	IDoubleDomainValidator,
@@ -43,6 +44,7 @@ IMapKeyType |
 IMapValueType | 
 IEnumProperty | 
 IProperty | 
+ICollectionSizeValidator | 
 IStringRegexValidator | 
 IStringLengthValidator | 
 IDoubleDomainValidator | 


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #[1292](https://github.com/accordproject/concerto/issues/1292)
<!--- Provide an overall summary of the pull request -->
- Extends `genmetamodel.js` to parse `metamodel.cto` and regenerate `lib/metamodel.json` automatically, keeping the JSON AST in sync with the CTO source
- Regenerated `metamodel.json` now includes `CollectionSizeValidator` (added in #84 but missing from the JSON)
- Regenerated the exported TS types and ensure codegen script uses locally declared metamodel to generated types

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
